### PR TITLE
fix: fix title max-width

### DIFF
--- a/src/app/components/title/title.component.scss
+++ b/src/app/components/title/title.component.scss
@@ -1,3 +1,8 @@
+mat-card {
+  max-width: 900px;
+  margin: 0px auto;
+}
+
 button {
   margin: 8px;
   border-radius: 25px;


### PR DESCRIPTION
<!-- Pull Request Template -->

The max width style was removed from the title when I moved it out of the content-container
![Screenshot 2025-05-06 at 10 25 27 PM](https://github.com/user-attachments/assets/f02200a7-fbf7-4f88-a9f2-df2fcfb75292)



This PR addresses this
![Screenshot 2025-05-06 at 10 26 42 PM](https://github.com/user-attachments/assets/9cd0287e-90f4-449a-ae67-2970c65ec151)


## Checklist

- [ ] Tests added or updated
- [ ] Lint passes
- [ ] Single logical change in this PR
